### PR TITLE
Throws an Exception if a file transfer fails

### DIFF
--- a/snapshot-service-impl/src/main/java/org/duracloud/snapshot/service/impl/SpaceItemWriter.java
+++ b/snapshot-service-impl/src/main/java/org/duracloud/snapshot/service/impl/SpaceItemWriter.java
@@ -206,6 +206,11 @@ public class SpaceItemWriter extends StepExecutionSupport implements ItemWriter<
 
             sw.stop();
 
+            if(null == props) { // Transfer failed
+                throw new IOException("Failed to retrieve " + contentId + " after " +
+                                      sw.getTime()/1000 + " seconds");
+            }
+
             log.info("Finished retrieving content: contentId={}, " +
                      " fileSize={}, file path={}, elapsedTimeMs={}, transferRateMbps={}",
                      contentId,


### PR DESCRIPTION
Provides a clear notice of file transfer failure rather than a NullPointerException based on a null properties response from RetrievalWorker