### PR TITLE
DURACLOUD-1261: Additional updates to resolve deployment errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,11 +9,11 @@
   <version>2.1.0-SNAPSHOT</version>
   <name>DuraCloud Snapshot</name>
   <description>Extension of DuraCloud to support dark archival storage systems</description>
-  <url>http://duracloud.org</url>
+  <url>https://duracloud.org</url>
 
   <organization>
-    <name>DuraSpace</name>
-    <url>http://www.duraspace.org</url>
+    <name>LYRASIS</name>
+    <url>https://lyrasis.org</url>
   </organization>
 
   <inceptionYear>2014</inceptionYear>
@@ -35,7 +35,7 @@
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0</url>
     </license>
   </licenses>
 
@@ -212,7 +212,7 @@
     <repository>
       <id>central</id>
       <name>Maven Repository Switchboard</name>
-      <url>http://repo1.maven.org/maven2</url>
+      <url>https://repo1.maven.org/maven2</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -695,6 +695,12 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-jaxb-annotations</artifactId>
         <version>${jackson.version}</version>
       </dependency>
 

--- a/snapshot-bridge-webapp/pom.xml
+++ b/snapshot-bridge-webapp/pom.xml
@@ -16,7 +16,7 @@
   </parent>
 
   <properties>
-    <jersey.version>2.5.1</jersey.version>
+    <jersey.version>2.25.1</jersey.version>
     <snapshot.database.username>snapshot</snapshot.database.username>
     <snapshot.database.password>snapshot</snapshot.database.password>
     <snapshot.database.url>jdbc:mysql://localhost/snapshot</snapshot.database.url>
@@ -167,20 +167,8 @@
       <version>${jersey.version}</version>
       <exclusions>
         <exclusion>
-          <groupId>org.codehaus.jackson</groupId>
-          <artifactId>jackson-core-asl</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.jackson</groupId>
-          <artifactId>jackson-mapper-asl</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.jackson</groupId>
-          <artifactId>jackson-jaxrs</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.jackson</groupId>
-          <artifactId>jackson-xc</artifactId>
+          <groupId>com.fasterxml.jackson.module</groupId>
+          <artifactId>jackson-module-jaxb-annotations</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -198,6 +186,11 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-jaxb-annotations</artifactId>
     </dependency>
 
     <dependency>
@@ -273,6 +266,12 @@
       <type>pom</type>
       <scope>test</scope>
       <version>${jersey.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>javax.servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
* Brings jersey versions of jackson dependencies in line to resolve deployment-time dependency conflicts 
* Updates POM file links to use HTTPS URLS