### PR TITLE
DURACLOUD-1281: Escapes JSON in snapshot content-properties.json file

### DIFF
--- a/snapshot-service-impl/src/main/java/org/duracloud/snapshot/service/impl/SpaceItemWriter.java
+++ b/snapshot-service-impl/src/main/java/org/duracloud/snapshot/service/impl/SpaceItemWriter.java
@@ -355,7 +355,12 @@ public class SpaceItemWriter extends StepExecutionSupport implements ItemWriter<
         StringBuffer sb = new StringBuffer(100);
         sb.append("{\n  \"" + contentId + "\": {\n");
         for (String propKey : propKeys) {
-            sb.append("    \"" + propKey + "\": \"" + props.get(propKey) + "\",\n");
+            String propValue = props.get(propKey);
+            // Escape special characters
+            propValue = propValue.replace("\\", "\\\\");
+            propValue = propValue.replace("\"", "\\\"");
+
+            sb.append("    \"" + propKey + "\": \"" + propValue + "\",\n");
         }
         sb.deleteCharAt(sb.length() - 2); // delete comma after last key/value pair
 


### PR DESCRIPTION
Test by:
* Build the bridge application and deploy locally
* Deploy DuraCloud locally with a Chronopolis storage provider configured to point to your local bridge application
* Create a space in DuraCloud and add a content item
* Add a property to the content item that includes a backslash character in the value (e.g. "C:\test\file.txt")
* Run the mill workman to make sure the file you added is added to the space manifest (verify the space manifest is correct afterward)
* Initiate a snapshot via the UI
* Look in the bridge content directory and look at the content-properties.json file for the new snapshot. 
* Verify that the property value you added uses double backslashes (e.g. "\\") for each backslash
* Copy the entire value of content-properties.json into https://jsonlint.com/ and verify that it is valid json