### PR TITLE
DURACLOUD-1150: Add REST API endpoints for total count, size and files in snapshots

### DIFF
--- a/snapshot-bridge-webapp/src/main/java/org/duracloud/snapshot/bridge/rest/SnapshotResource.java
+++ b/snapshot-bridge-webapp/src/main/java/org/duracloud/snapshot/bridge/rest/SnapshotResource.java
@@ -63,6 +63,7 @@ import org.duracloud.snapshot.dto.bridge.GetSnapshotListBridgeResult;
 import org.duracloud.snapshot.dto.bridge.GetSnapshotTotalCountBridgeResult;
 import org.duracloud.snapshot.dto.bridge.GetSnapshotTotalFilesBridgeResult;
 import org.duracloud.snapshot.dto.bridge.GetSnapshotTotalSizeBridgeResult;
+import org.duracloud.snapshot.dto.bridge.GetSnapshotTotalsBridgeResult;
 import org.duracloud.snapshot.dto.bridge.RestartSnapshotBridgeResult;
 import org.duracloud.snapshot.dto.bridge.SnapshotErrorBridgeParameters;
 import org.duracloud.snapshot.dto.bridge.SnapshotErrorBridgeResult;
@@ -217,11 +218,11 @@ public class SnapshotResource {
                          @QueryParam("storeId") String storeId,
                          @QueryParam("status") SnapshotStatus status) {
         try {
-            long count = getSnapshotsCount(host, storeId, status);
+            long totalCount = getSnapshotsCount(host, storeId, status);
 
-            log.debug("returning {} count of snapshots", count);
+            log.debug("returning {} total count of snapshots", totalCount);
             return Response.ok()
-                           .entity(new GetSnapshotTotalCountBridgeResult(count))
+                           .entity(new GetSnapshotTotalCountBridgeResult(totalCount))
                            .build();
         } catch (Exception ex) {
             log.error(ex.getMessage(), ex);
@@ -277,11 +278,11 @@ public class SnapshotResource {
                           @QueryParam("storeId") String storeId,
                           @QueryParam("status") SnapshotStatus status) {
         try {
-            long totalContent = getSnapshotsSize(host, storeId, status);
+            long totalSize = getSnapshotsSize(host, storeId, status);
 
-            log.debug("returning {} total size in bytes of snapshots", totalContent);
+            log.debug("returning {} total size in bytes of snapshots", totalSize);
             return Response.ok()
-                           .entity(new GetSnapshotTotalSizeBridgeResult(totalContent))
+                           .entity(new GetSnapshotTotalSizeBridgeResult(totalSize))
                            .build();
         } catch (Exception ex) {
             log.error(ex.getMessage(), ex);
@@ -349,11 +350,11 @@ public class SnapshotResource {
                          @QueryParam("storeId") String storeId,
                          @QueryParam("status") SnapshotStatus status) {
         try {
-            long totalContent = getSnapshotsFiles(host, storeId, status);
+            long totalFiles = getSnapshotsFiles(host, storeId, status);
 
-            log.debug("returning {} total number of files in snapshots", totalContent);
+            log.debug("returning {} total number of files in snapshots", totalFiles);
             return Response.ok()
-                           .entity(new GetSnapshotTotalFilesBridgeResult(totalContent))
+                           .entity(new GetSnapshotTotalFilesBridgeResult(totalFiles))
                            .build();
         } catch (Exception ex) {
             log.error(ex.getMessage(), ex);
@@ -407,6 +408,36 @@ public class SnapshotResource {
         }
 
         return totalFiles;
+    }
+
+    /**
+     * Returns the total count, size and files of snapshots
+     *
+     * @return
+     */
+    @Path("total")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response total(@QueryParam("host") String host,
+                          @QueryParam("storeId") String storeId,
+                          @QueryParam("status") SnapshotStatus status) {
+        try {
+            long totalCount = getSnapshotsCount(host, storeId, status);
+            long totalSize = getSnapshotsSize(host, storeId, status);
+            long totalFiles = getSnapshotsFiles(host, storeId, status);
+
+            log.debug("returning {} total count of snapshots", totalCount);
+            log.debug("returning {} total size in bytes of snapshots", totalSize);
+            log.debug("returning {} total number of files in snapshots", totalFiles);
+            return Response.ok()
+                           .entity(new GetSnapshotTotalsBridgeResult(totalCount, totalSize, totalFiles))
+                           .build();
+        } catch (Exception ex) {
+            log.error(ex.getMessage(), ex);
+            return Response.serverError()
+                           .entity(new ResponseDetails(ex.getMessage()))
+                           .build();
+        }
     }
 
     @Path("{snapshotId}")

--- a/snapshot-bridge-webapp/src/main/java/org/duracloud/snapshot/bridge/rest/SnapshotResource.java
+++ b/snapshot-bridge-webapp/src/main/java/org/duracloud/snapshot/bridge/rest/SnapshotResource.java
@@ -58,9 +58,10 @@ import org.duracloud.snapshot.dto.bridge.CreateSnapshotBridgeParameters;
 import org.duracloud.snapshot.dto.bridge.CreateSnapshotBridgeResult;
 import org.duracloud.snapshot.dto.bridge.GetSnapshotBridgeResult;
 import org.duracloud.snapshot.dto.bridge.GetSnapshotContentBridgeResult;
-import org.duracloud.snapshot.dto.bridge.GetSnapshotCountBridgeResult;
 import org.duracloud.snapshot.dto.bridge.GetSnapshotHistoryBridgeResult;
 import org.duracloud.snapshot.dto.bridge.GetSnapshotListBridgeResult;
+import org.duracloud.snapshot.dto.bridge.GetSnapshotTotalCountBridgeResult;
+import org.duracloud.snapshot.dto.bridge.GetSnapshotTotalSizeBridgeResult;
 import org.duracloud.snapshot.dto.bridge.RestartSnapshotBridgeResult;
 import org.duracloud.snapshot.dto.bridge.SnapshotErrorBridgeParameters;
 import org.duracloud.snapshot.dto.bridge.SnapshotErrorBridgeResult;
@@ -204,22 +205,22 @@ public class SnapshotResource {
     }
 
     /**
-     * Returns a count of snapshots.
+     * Returns the total count of snapshots.
      *
      * @return
      */
-    @Path("count")
+    @Path("total/count")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Response count(@QueryParam("host") String host,
                          @QueryParam("storeId") String storeId,
                          @QueryParam("status") SnapshotStatus status) {
         try {
-            long count = countSnapshots(host, storeId, status);
+            long count = getSnapshotsCount(host, storeId, status);
 
             log.debug("returning {} count of snapshots", count);
             return Response.ok()
-                           .entity(new GetSnapshotCountBridgeResult(count))
+                           .entity(new GetSnapshotTotalCountBridgeResult(count))
                            .build();
         } catch (Exception ex) {
             log.error(ex.getMessage(), ex);
@@ -230,11 +231,11 @@ public class SnapshotResource {
     }
 
     /*
-     * Returns a snapshot count. The parameters of host, store ID and status are all
+     * Returns a total count of snapshots. The parameters of host, store ID and status are all
      * considered optional, so depending on which are provided (i.e. not null), the
      * query used will vary.
      */
-    protected long countSnapshots(String host,
+    protected long getSnapshotsCount(String host,
                                            String storeId,
                                            SnapshotStatus status) {
         if (null != host) {
@@ -261,6 +262,78 @@ public class SnapshotResource {
         } else { // No filters
             return snapshotRepo.count();
         }
+    }
+
+    /**
+     * Returns the total size of snapshot contents.
+     *
+     * @return
+     */
+    @Path("total/size")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response size(@QueryParam("host") String host,
+                          @QueryParam("storeId") String storeId,
+                          @QueryParam("status") SnapshotStatus status) {
+        try {
+            long totalContent = getSnapshotsSize(host, storeId, status);
+
+            log.debug("returning {} total content of snapshots", totalContent);
+            return Response.ok()
+                           .entity(new GetSnapshotTotalSizeBridgeResult(totalContent))
+                           .build();
+        } catch (Exception ex) {
+            log.error(ex.getMessage(), ex);
+            return Response.serverError()
+                           .entity(new ResponseDetails(ex.getMessage()))
+                           .build();
+        }
+    }
+
+    /*
+     * Returns a total size of snapshots. The parameters of host, store ID and status are all
+     * considered optional, so depending on which are provided (i.e. not null), the
+     * query used will vary.
+     */
+    protected long getSnapshotsSize(String host,
+                                  String storeId,
+                                  SnapshotStatus status) {
+        long totalSizeInBytes = 0L;
+        List<Snapshot> snapshots = null;
+
+        if (null != host) {
+            if (null != storeId) {
+                if (null != status) { // Host & Store ID & Status
+                    snapshots = snapshotRepo.findBySourceHostAndSourceStoreIdAndStatus(host, storeId, status);
+                } else { // Host & Store ID
+                    snapshots = snapshotRepo.findBySourceHostAndSourceStoreId(host, storeId);
+                }
+            } else if (null != status) { // Host & Status
+                snapshots = snapshotRepo.findBySourceHostAndStatus(host, status);
+            } else { // Host
+                snapshots = snapshotRepo.findBySourceHost(host);
+            }
+        } else if (null != storeId) {
+            if (null != status) { // Store ID & Status
+                snapshots = snapshotRepo.findBySourceStoreIdAndStatus(storeId, status);
+            } else { // Store ID
+                snapshots = snapshotRepo.findBySourceStoreId(storeId);
+            }
+        } else if (null != status) { // Status
+            snapshots = snapshotRepo.findByStatusOrderBySnapshotDateAsc(status);
+        } else { // No filters
+            snapshots = snapshotRepo.findAll();
+        }
+
+        if (null != snapshots) {
+            Iterator<Snapshot> snapshotsItr = snapshots.iterator();
+            while (snapshotsItr.hasNext()) {
+                Snapshot snapshot = snapshotsItr.next();
+                totalSizeInBytes += snapshot.getTotalSizeInBytes();
+            }
+        }
+
+        return totalSizeInBytes;
     }
 
     @Path("{snapshotId}")

--- a/snapshot-bridge-webapp/src/test/java/org/duracloud/snapshot/bridge/rest/SnapshotResourceTest.java
+++ b/snapshot-bridge-webapp/src/test/java/org/duracloud/snapshot/bridge/rest/SnapshotResourceTest.java
@@ -59,6 +59,7 @@ import org.duracloud.snapshot.service.SnapshotManager;
 import org.duracloud.snapshot.service.impl.StoreClientHelper;
 import org.easymock.Capture;
 import org.easymock.CaptureType;
+import org.easymock.EasyMock;
 import org.easymock.Mock;
 import org.junit.Test;
 import org.springframework.batch.core.BatchStatus;
@@ -506,6 +507,83 @@ public class SnapshotResourceTest extends SnapshotTestBase {
             .andReturn(new ArrayList<Snapshot>());
         replayAll();
         resource.listSnapshots(null, storeId, status);
+    }
+
+    @Test
+    public void testCountSnapshotsNoParams() {
+        expect(snapshotRepo.count())
+            .andReturn(Long.valueOf(1));
+        replayAll();
+        resource.countSnapshots(null, null, null);
+    }
+
+    @Test
+    public void testCountSnapshotsHost() {
+        String host = "host";
+        expect(snapshotRepo.countBySourceHost(host))
+            .andReturn(Long.valueOf(1));
+        replayAll();
+        resource.countSnapshots(host, null, null);
+    }
+
+    @Test
+    public void testCountSnapshotsHostStoreId() {
+        String host = "host";
+        String storeId = "store-id";
+        expect(snapshotRepo.countBySourceHostAndSourceStoreId(host, storeId))
+            .andReturn(Long.valueOf(1));
+        replayAll();
+        resource.countSnapshots(host, storeId, null);
+    }
+
+    @Test
+    public void testCountSnapshotsHostStoreIdStatus() {
+        String host = "host";
+        String storeId = "store-id";
+        SnapshotStatus status = SnapshotStatus.SNAPSHOT_COMPLETE;
+        expect(snapshotRepo
+                   .countBySourceHostAndSourceStoreIdAndStatus(host, storeId, status))
+            .andReturn(Long.valueOf(1));
+        replayAll();
+        resource.countSnapshots(host, storeId, status);
+    }
+
+    @Test
+    public void testCountSnapshotStoreId() {
+        String storeId = "store-id";
+        expect(snapshotRepo.countBySourceStoreId(storeId))
+            .andReturn(Long.valueOf(1));
+        replayAll();
+        resource.countSnapshots(null, storeId, null);
+    }
+
+    @Test
+    public void testCountSnapshotsStatus() {
+        SnapshotStatus status = SnapshotStatus.SNAPSHOT_COMPLETE;
+        expect(snapshotRepo.countByStatusOrderBySnapshotDateAsc(status))
+            .andReturn(Long.valueOf(1));
+        replayAll();
+        resource.countSnapshots(null, null, status);
+    }
+
+    @Test
+    public void testCountSnapshotsHostStatus() {
+        String host = "host";
+        SnapshotStatus status = SnapshotStatus.SNAPSHOT_COMPLETE;
+        expect(snapshotRepo.countBySourceHostAndStatus(host, status))
+            .andReturn(Long.valueOf(1));
+        replayAll();
+        resource.countSnapshots(host, null, status);
+    }
+
+    @Test
+    public void testCountSnapshotsStoreIdStatus() {
+        String storeId = "store-id";
+        SnapshotStatus status = SnapshotStatus.SNAPSHOT_COMPLETE;
+        expect(snapshotRepo.countBySourceStoreIdAndStatus(storeId, status))
+            .andReturn(Long.valueOf(1));
+        replayAll();
+        resource.countSnapshots(null, storeId, status);
     }
 
     @Test

--- a/snapshot-bridge-webapp/src/test/java/org/duracloud/snapshot/bridge/rest/SnapshotResourceTest.java
+++ b/snapshot-bridge-webapp/src/test/java/org/duracloud/snapshot/bridge/rest/SnapshotResourceTest.java
@@ -548,7 +548,7 @@ public class SnapshotResourceTest extends SnapshotTestBase {
     }
 
     @Test
-    public void testCountSnapshotStoreId() {
+    public void testCountSnapshotsStoreId() {
         String storeId = "store-id";
         expect(snapshotRepo.countBySourceStoreId(storeId))
             .andReturn(Long.valueOf(1));
@@ -583,6 +583,83 @@ public class SnapshotResourceTest extends SnapshotTestBase {
             .andReturn(Long.valueOf(1));
         replayAll();
         resource.getSnapshotsCount(null, storeId, status);
+    }
+
+    @Test
+    public void testCountSnapshotsFilesNoParams() {
+        expect(snapshotRepo.findAll())
+            .andReturn(new ArrayList<Snapshot>());
+        replayAll();
+        resource.getSnapshotsFiles(null, null, null);
+    }
+
+    @Test
+    public void testCountSnapshotsFilesHost() {
+        String host = "host";
+        expect(snapshotRepo.findBySourceHost(host))
+            .andReturn(new ArrayList<Snapshot>());
+        replayAll();
+        resource.getSnapshotsFiles(host, null, null);
+    }
+
+    @Test
+    public void testCountSnapshotsFilesHostStoreId() {
+        String host = "host";
+        String storeId = "store-id";
+        expect(snapshotRepo.findBySourceHostAndSourceStoreId(host, storeId))
+            .andReturn(new ArrayList<Snapshot>());
+        replayAll();
+        resource.getSnapshotsFiles(host, storeId, null);
+    }
+
+    @Test
+    public void testCountSnapshotsFilesHostStoreIdStatus() {
+        String host = "host";
+        String storeId = "store-id";
+        SnapshotStatus status = SnapshotStatus.SNAPSHOT_COMPLETE;
+        expect(snapshotRepo
+                   .findBySourceHostAndSourceStoreIdAndStatus(host, storeId, status))
+            .andReturn(new ArrayList<Snapshot>());
+        replayAll();
+        resource.getSnapshotsFiles(host, storeId, status);
+    }
+
+    @Test
+    public void testCountSnapshotsFilesStoreId() {
+        String storeId = "store-id";
+        expect(snapshotRepo.findBySourceStoreId(storeId))
+            .andReturn(new ArrayList<Snapshot>());
+        replayAll();
+        resource.getSnapshotsFiles(null, storeId, null);
+    }
+
+    @Test
+    public void testCountSnapshotsFilesStatus() {
+        SnapshotStatus status = SnapshotStatus.SNAPSHOT_COMPLETE;
+        expect(snapshotRepo.findByStatusOrderBySnapshotDateAsc(status))
+            .andReturn(new ArrayList<Snapshot>());
+        replayAll();
+        resource.getSnapshotsFiles(null, null, status);
+    }
+
+    @Test
+    public void testCountSnapshotsFilesHostStatus() {
+        String host = "host";
+        SnapshotStatus status = SnapshotStatus.SNAPSHOT_COMPLETE;
+        expect(snapshotRepo.findBySourceHostAndStatus(host, status))
+            .andReturn(new ArrayList<Snapshot>());
+        replayAll();
+        resource.getSnapshotsFiles(host, null, status);
+    }
+
+    @Test
+    public void testCountSnapshotsFilesStoreIdStatus() {
+        String storeId = "store-id";
+        SnapshotStatus status = SnapshotStatus.SNAPSHOT_COMPLETE;
+        expect(snapshotRepo.findBySourceStoreIdAndStatus(storeId, status))
+            .andReturn(new ArrayList<Snapshot>());
+        replayAll();
+        resource.getSnapshotsFiles(null, storeId, status);
     }
 
     @Test

--- a/snapshot-bridge-webapp/src/test/java/org/duracloud/snapshot/bridge/rest/SnapshotResourceTest.java
+++ b/snapshot-bridge-webapp/src/test/java/org/duracloud/snapshot/bridge/rest/SnapshotResourceTest.java
@@ -59,7 +59,6 @@ import org.duracloud.snapshot.service.SnapshotManager;
 import org.duracloud.snapshot.service.impl.StoreClientHelper;
 import org.easymock.Capture;
 import org.easymock.CaptureType;
-import org.easymock.EasyMock;
 import org.easymock.Mock;
 import org.junit.Test;
 import org.springframework.batch.core.BatchStatus;
@@ -514,7 +513,7 @@ public class SnapshotResourceTest extends SnapshotTestBase {
         expect(snapshotRepo.count())
             .andReturn(Long.valueOf(1));
         replayAll();
-        resource.countSnapshots(null, null, null);
+        resource.getSnapshotsCount(null, null, null);
     }
 
     @Test
@@ -523,7 +522,7 @@ public class SnapshotResourceTest extends SnapshotTestBase {
         expect(snapshotRepo.countBySourceHost(host))
             .andReturn(Long.valueOf(1));
         replayAll();
-        resource.countSnapshots(host, null, null);
+        resource.getSnapshotsCount(host, null, null);
     }
 
     @Test
@@ -533,7 +532,7 @@ public class SnapshotResourceTest extends SnapshotTestBase {
         expect(snapshotRepo.countBySourceHostAndSourceStoreId(host, storeId))
             .andReturn(Long.valueOf(1));
         replayAll();
-        resource.countSnapshots(host, storeId, null);
+        resource.getSnapshotsCount(host, storeId, null);
     }
 
     @Test
@@ -545,7 +544,7 @@ public class SnapshotResourceTest extends SnapshotTestBase {
                    .countBySourceHostAndSourceStoreIdAndStatus(host, storeId, status))
             .andReturn(Long.valueOf(1));
         replayAll();
-        resource.countSnapshots(host, storeId, status);
+        resource.getSnapshotsCount(host, storeId, status);
     }
 
     @Test
@@ -554,7 +553,7 @@ public class SnapshotResourceTest extends SnapshotTestBase {
         expect(snapshotRepo.countBySourceStoreId(storeId))
             .andReturn(Long.valueOf(1));
         replayAll();
-        resource.countSnapshots(null, storeId, null);
+        resource.getSnapshotsCount(null, storeId, null);
     }
 
     @Test
@@ -563,7 +562,7 @@ public class SnapshotResourceTest extends SnapshotTestBase {
         expect(snapshotRepo.countByStatusOrderBySnapshotDateAsc(status))
             .andReturn(Long.valueOf(1));
         replayAll();
-        resource.countSnapshots(null, null, status);
+        resource.getSnapshotsCount(null, null, status);
     }
 
     @Test
@@ -573,7 +572,7 @@ public class SnapshotResourceTest extends SnapshotTestBase {
         expect(snapshotRepo.countBySourceHostAndStatus(host, status))
             .andReturn(Long.valueOf(1));
         replayAll();
-        resource.countSnapshots(host, null, status);
+        resource.getSnapshotsCount(host, null, status);
     }
 
     @Test
@@ -583,7 +582,7 @@ public class SnapshotResourceTest extends SnapshotTestBase {
         expect(snapshotRepo.countBySourceStoreIdAndStatus(storeId, status))
             .andReturn(Long.valueOf(1));
         replayAll();
-        resource.countSnapshots(null, storeId, status);
+        resource.getSnapshotsCount(null, storeId, status);
     }
 
     @Test

--- a/snapshot-common-db/src/main/java/org/duracloud/snapshot/db/repo/SnapshotContentItemRepo.java
+++ b/snapshot-common-db/src/main/java/org/duracloud/snapshot/db/repo/SnapshotContentItemRepo.java
@@ -35,6 +35,8 @@ public interface SnapshotContentItemRepo extends JpaRepository<SnapshotContentIt
 
     public long countBySnapshotName(@Param("snapshotName") String snapshotName);
 
+    public long countBySnapshotId(@Param("snapshotId") Long snapshotId);
+
     /**
      * @param snapshotName
      * @param pageable

--- a/snapshot-common-db/src/main/java/org/duracloud/snapshot/db/repo/SnapshotRepo.java
+++ b/snapshot-common-db/src/main/java/org/duracloud/snapshot/db/repo/SnapshotRepo.java
@@ -89,6 +89,61 @@ public interface SnapshotRepo extends JpaRepository<Snapshot, Long> {
     public Snapshot findBySnapshotAlternateIds(String alternateId);
 
     /**
+     * @return number of total snapshots
+     */
+    public long count();
+
+    /**
+     * @param host where snapshot originated
+     * @return number of snapshots with the given host
+     */
+    public long countBySourceHost(String host);
+
+    /**
+     * @param storeId storage provider ID
+     * @return number of snapshots with the given store ID
+     */
+    public long countBySourceStoreId(String storeId);
+
+    /**
+     * @param host    where snapshot originated
+     * @param storeId storage provider ID
+     * @return number of snapshots with the given host and store ID
+     */
+    public long countBySourceHostAndSourceStoreId(String host, String storeId);
+
+    /**
+     * @param status current snapshot status
+     * @return number of snapshots with the given status
+     */
+    public long countByStatusOrderBySnapshotDateAsc(SnapshotStatus status);
+
+    /**
+     * @param host   where snapshot originated
+     * @param status current snapshot status
+     * @return number of snapshots with the given host and status
+     */
+    public long countBySourceHostAndStatus(String host, SnapshotStatus status);
+
+    /**
+     * @param storeId storage provider ID
+     * @param status  current snapshot status
+     * @return number of snapshots with the given store ID and status
+     */
+    public long countBySourceStoreIdAndStatus(String storeId,
+                                                       SnapshotStatus status);
+
+    /**
+     * @param host    where snapshot originated
+     * @param storeId storage provider ID
+     * @param status  current snapshot status
+     * @return number of  snapshots with the given host, store ID, and status
+     */
+    public long countBySourceHostAndSourceStoreIdAndStatus(String host,
+                                                                    String storeId,
+                                                                    SnapshotStatus status);
+
+    /**
      * @param snapshotId ID of snapshot
      */
     public void deleteByName(String snapshotId);

--- a/snapshot-common-db/src/main/java/org/duracloud/snapshot/db/repo/SnapshotRepo.java
+++ b/snapshot-common-db/src/main/java/org/duracloud/snapshot/db/repo/SnapshotRepo.java
@@ -89,46 +89,46 @@ public interface SnapshotRepo extends JpaRepository<Snapshot, Long> {
     public Snapshot findBySnapshotAlternateIds(String alternateId);
 
     /**
-     * @return number of total snapshots
+     * @return count of snapshots
      */
     public long count();
 
     /**
      * @param host where snapshot originated
-     * @return number of snapshots with the given host
+     * @return count of snapshots with the given host
      */
     public long countBySourceHost(String host);
 
     /**
      * @param storeId storage provider ID
-     * @return number of snapshots with the given store ID
+     * @return count of snapshots with the given store ID
      */
     public long countBySourceStoreId(String storeId);
 
     /**
      * @param host    where snapshot originated
      * @param storeId storage provider ID
-     * @return number of snapshots with the given host and store ID
+     * @return count of snapshots with the given host and store ID
      */
     public long countBySourceHostAndSourceStoreId(String host, String storeId);
 
     /**
      * @param status current snapshot status
-     * @return number of snapshots with the given status
+     * @return count of snapshots with the given status
      */
     public long countByStatusOrderBySnapshotDateAsc(SnapshotStatus status);
 
     /**
      * @param host   where snapshot originated
      * @param status current snapshot status
-     * @return number of snapshots with the given host and status
+     * @return count of snapshots with the given host and status
      */
     public long countBySourceHostAndStatus(String host, SnapshotStatus status);
 
     /**
      * @param storeId storage provider ID
      * @param status  current snapshot status
-     * @return number of snapshots with the given store ID and status
+     * @return count of snapshots with the given store ID and status
      */
     public long countBySourceStoreIdAndStatus(String storeId,
                                                        SnapshotStatus status);
@@ -137,7 +137,7 @@ public interface SnapshotRepo extends JpaRepository<Snapshot, Long> {
      * @param host    where snapshot originated
      * @param storeId storage provider ID
      * @param status  current snapshot status
-     * @return number of  snapshots with the given host, store ID, and status
+     * @return count of snapshots with the given host, store ID, and status
      */
     public long countBySourceHostAndSourceStoreIdAndStatus(String host,
                                                                     String storeId,


### PR DESCRIPTION
**This PR adds new REST API endpoints for 1) total snapshots counts, 2) total snapshots sizes in bytes, and 3) total snapshot files based on a given search criteria. The search criteria are host, storeId, or status.*
* * *

**JIRA Ticket**: https://duracloud.atlassian.net/browse/DURACLOUD-1150

# How should this be tested?

* Build and install (push to local maven repository the duracloud-1150 branch of DuraCloud (https://github.com/duracloud/duracloud/pull/148)
* Build and deploy locally this branch of the Bridge. 
* Have 1+ snapshots in the Bridge
* Go to the endpoints for the new counts: 
    * https://localhost:8080/snapshot/total/count
    * https://localhost:8080/snapshot/total/size
    * https://localhost:8080/snapshot/total/files

# Additional Notes:

As mentioned in the test instructions this PR depends on another PR in the DuraCloud repository that contains the Bridge result classes for these new endpoints.

# Interested parties
@duracloud/committers
