### PR TITLE
DURACLOUD-1278: Adds Github Actions build to replace Travis CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,77 @@
+# Continuous Integration Build via GitHub Actions
+name: CI Build
+
+# Run this Build for all pushes and PRs
+on: [push, pull_request]
+
+jobs:
+  ci-build:
+    runs-on: ubuntu-latest
+    env:
+      # Specify memory for Maven
+      MAVEN_OPTS: "-Xmx256M"
+    steps:
+    # Output current build environment
+    - run: echo "This is a CI build of branch ${{ github.ref }} in repository ${{ github.repository }}"
+    - run: echo "This job was triggered by a ${{ github.event_name }} event and is running on a ${{ runner.os }} server"
+
+    # https://github.com/actions/checkout
+    - name: Checkout codebase
+      uses: actions/checkout@v2
+
+    # https://github.com/actions/setup-java
+    - name: Install JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: 11
+        distribution: adopt
+
+    # https://github.com/actions/cache
+    - name: Cache Maven dependencies
+      uses: actions/cache@v2
+      with:
+        # Cache entire ~/.m2/repository
+        path: ~/.m2/repository
+        # Cache key is hash of all pom.xml files. Therefore any changes to POMs will invalidate cache
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-maven-
+
+    # Run build and execute tests
+    - name: Build and Run unit tests
+      run: mvn clean install -DskipIntTests -DskipDeploy --batch-mode
+
+    # https://github.com/actions/setup-java
+    # Sets up Java again, preparing the settings.xml to deploy to Sonatype (Maven)
+    # ONLY on push to develop branch (using Sonatype snapshots repo)
+    - name: Set up for deploy to Sonatype
+      uses: actions/setup-java@v2
+      if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
+      with:
+        java-version: 11
+        distribution: adopt
+        server-id: sonatype-snapshots # Value of the distributionManagement/repository/id field of the pom.xml
+        server-username: SONATYPE_USERNAME # env variable for sonatype username
+        server-password: SONATYPE_PASSWORD # env variable for sonatype password
+        gpg-private-key: ${{ secrets.CODESIGN_GPG_KEY }} # Value of the GPG private key to import
+        gpg-passphrase: CODESIGN_GPG_PASSPHRASE # env variable for GPG private key passphrase
+    # ONLY on push to main branch (using Sonatype releases repo)
+    - name: Set up for deploy to Sonatype
+      uses: actions/setup-java@v2
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      with:
+        java-version: 11
+        distribution: adopt
+        server-id: sonatype-releases # Value of the distributionManagement/repository/id field of the pom.xml
+        server-username: SONATYPE_USERNAME # env variable for sonatype username
+        server-password: SONATYPE_PASSWORD # env variable for sonatype password
+        gpg-private-key: ${{ secrets.CODESIGN_GPG_KEY }} # Value of the GPG private key to import
+        gpg-passphrase: CODESIGN_GPG_PASSPHRASE # env variable for GPG private key passphrase
+
+    # Execute deployment to sonatype (only on push to develop or main branches)
+    - name: Publish to Sonatype
+      if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
+      run: mvn deploy -DreleaseBuild -DskipTests -DskipDeploy --batch-mode
+      env:
+        SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+        SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+        CODESIGN_GPG_PASSPHRASE: ${{ secrets.CODESIGN_GPG_PASSPHRASE }}


### PR DESCRIPTION
This is a copy of the Github Actions CI build from the DuraCloud baseline.

This PR leaves the Travis CI configuration in place to serve as reference when adding a Github Action to capture release artifacts.