### PR TITLE
Dependency Updates

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Specify memory for Maven
-      MAVEN_OPTS: "-Xmx256M"
+      MAVEN_OPTS: "-Xmx512M"
     steps:
     # Output current build environment
     - run: echo "This is a CI build of branch ${{ github.ref }} in repository ${{ github.repository }}"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -20,10 +20,10 @@ jobs:
       uses: actions/checkout@v2
 
     # https://github.com/actions/setup-java
-    - name: Install JDK 11
+    - name: Install JDK 17
       uses: actions/setup-java@v2
       with:
-        java-version: 11
+        java-version: 17
         distribution: adopt
 
     # https://github.com/actions/cache
@@ -47,7 +47,7 @@ jobs:
       uses: actions/setup-java@v2
       if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
       with:
-        java-version: 11
+        java-version: 17
         distribution: adopt
         server-id: sonatype-snapshots # Value of the distributionManagement/repository/id field of the pom.xml
         server-username: SONATYPE_USERNAME # env variable for sonatype username
@@ -59,7 +59,7 @@ jobs:
       uses: actions/setup-java@v2
       if: github.ref == 'refs/heads/main' && github.event_name == 'push'
       with:
-        java-version: 11
+        java-version: 17
         distribution: adopt
         server-id: sonatype-releases # Value of the distributionManagement/repository/id field of the pom.xml
         server-username: SONATYPE_USERNAME # env variable for sonatype username

--- a/pom.xml
+++ b/pom.xml
@@ -191,8 +191,9 @@
     <springframework.data.jpa.version>2.7.15</springframework.data.jpa.version>
     <springframework.security.version>5.8.5</springframework.security.version>
     <spring.batch.version>4.3.10</spring.batch.version>
-    <hibernate.version>5.4.3.Final</hibernate.version>
-    <mysql.connector.version>5.1.49</mysql.connector.version>
+    <hibernate.version>5.4.33.Final</hibernate.version>
+    <hibernate.validator.version>5.4.3.Final</hibernate.validator.version>
+    <mysql.connector.version>8.2.0</mysql.connector.version>
     <duracloud.version>8.0.0</duracloud.version>
     <duracloud.db.version>8.0.0</duracloud.db.version>
     <duraspace-codestyle.version>1.1.0</duraspace-codestyle.version>
@@ -674,9 +675,16 @@
       </dependency>
 
       <dependency>
-        <groupId>mysql</groupId>
-        <artifactId>mysql-connector-java</artifactId>
+        <groupId>com.mysql</groupId>
+        <artifactId>mysql-connector-j</artifactId>
         <version>${mysql.connector.version}</version>
+      </dependency>
+
+      <!-- Needed for convergence issue w/ Hibernate -->
+      <dependency>
+        <groupId>org.jboss.logging</groupId>
+        <artifactId>jboss-logging</artifactId>
+        <version>3.4.1.Final</version>
       </dependency>
 
       <dependency>
@@ -688,12 +696,8 @@
       <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-validator</artifactId>
-        <version>${hibernate.version}</version>
+        <version>${hibernate.validator.version}</version>
         <exclusions>
-          <exclusion>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-          </exclusion>
           <exclusion>
             <groupId>com.fasterxml</groupId>
             <artifactId>classmate</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -186,10 +186,10 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <slf4j.version>1.7.6</slf4j.version>
-    <springframework.version>4.3.30.RELEASE</springframework.version>
-    <springframework.data.jpa.version>1.11.23.RELEASE</springframework.data.jpa.version>
-    <springframework.security.version>4.2.20.RELEASE</springframework.security.version>
-    <spring.batch.version>3.0.7.RELEASE</spring.batch.version>
+    <springframework.version>5.3.29</springframework.version>
+    <springframework.data.jpa.version>2.7.15</springframework.data.jpa.version>
+    <springframework.security.version>5.8.5</springframework.security.version>
+    <spring.batch.version>4.3.10</spring.batch.version>
     <hibernate.version>5.4.3.Final</hibernate.version>
     <mysql.connector.version>5.1.49</mysql.connector.version>
     <duracloud.version>7.1.0</duracloud.version>

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,8 @@
     <log.level.default>INFO</log.level.default>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <slf4j.version>1.7.6</slf4j.version>
+    <slf4j.version>2.0.9</slf4j.version>
+    <logback.version>1.4.14</logback.version>
     <springframework.version>5.3.29</springframework.version>
     <springframework.data.jpa.version>2.7.15</springframework.data.jpa.version>
     <springframework.security.version>5.8.5</springframework.security.version>
@@ -657,7 +658,7 @@
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.2.0</version>
+        <version>${logback.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -726,20 +726,10 @@
       </dependency>
 
       <dependency>
-        <groupId>com.wix</groupId>
-        <artifactId>wix-embedded-mysql</artifactId>
-        <version>2.2.10</version>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>mysql</artifactId>
+        <version>1.19.3</version>
         <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>2.3</version>
+            <version>3.3.0</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.2.0</version>
+            <version>3.6.3</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>
@@ -158,7 +158,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.0.1</version>
+            <version>3.1.0</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -263,7 +263,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.6</version>
+        <version>1.6.13</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>sonatype-releases</serverId>
@@ -278,7 +278,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <release>11</release>
           <encoding>UTF-8</encoding>
@@ -306,7 +306,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.16</version>
+        <version>3.2.3</version>
         <configuration>
           <systemProperties/>
         </configuration>
@@ -363,7 +363,7 @@
 
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.3.1</version>
         <executions>
           <execution>
             <id>copy-resources</id>
@@ -387,7 +387,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>3.4.1</version>
         <executions>
           <execution>
             <goals>
@@ -405,7 +405,7 @@
                   </excludes>
                 </bannedDependencies>
                 <requireMavenVersion>
-                  <version>[3.5.0,4.0.0)</version>
+                  <version>[3.6.3,4.0.0)</version>
                 </requireMavenVersion>
               </rules>
             </configuration>
@@ -417,7 +417,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.3.1</version>
         <executions>
           <execution>
             <id>verify-style</id>

--- a/pom.xml
+++ b/pom.xml
@@ -192,8 +192,8 @@
     <spring.batch.version>4.3.10</spring.batch.version>
     <hibernate.version>5.4.3.Final</hibernate.version>
     <mysql.connector.version>5.1.49</mysql.connector.version>
-    <duracloud.version>7.1.0</duracloud.version>
-    <duracloud.db.version>7.1.0</duracloud.db.version>
+    <duracloud.version>8.0.0</duracloud.version>
+    <duracloud.db.version>8.0.0</duracloud.db.version>
     <duraspace-codestyle.version>1.1.0</duraspace-codestyle.version>
     <enforce-victims.rule.version>1.3.4</enforce-victims.rule.version>
     <jackson.version>2.12.3</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
     <duracloud.db.version>8.0.0</duracloud.db.version>
     <duraspace-codestyle.version>1.1.0</duraspace-codestyle.version>
     <enforce-victims.rule.version>1.3.4</enforce-victims.rule.version>
-    <jackson.version>2.12.3</jackson.version>
+    <jackson.version>2.16.0</jackson.version>
     <jaxb.api.version>2.3.1</jaxb.api.version>
     <jaxb.runtime.version>2.3.3</jaxb.runtime.version>
     <javax.annotation.api.version>1.3.2</javax.annotation.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.11.0</version>
         <configuration>
-          <release>11</release>
+          <release>17</release>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -735,6 +735,10 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -782,7 +786,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.1</version>
+      <version>3.12.0</version>
     </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -721,7 +721,7 @@
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>4.0.2</version>
+        <version>5.2.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -568,7 +568,7 @@
       <dependency>
         <groupId>javax.interceptor</groupId>
         <artifactId>javax.interceptor-api</artifactId>
-        <version>1.2</version>
+        <version>1.2.2</version>
       </dependency>
 
       <dependency>
@@ -604,7 +604,7 @@
       <dependency>
         <groupId>org.aspectj</groupId>
         <artifactId>aspectjweaver</artifactId>
-        <version>1.8.8</version>
+        <version>1.9.21</version>
       </dependency>
 
       <!-- Spring Batch dependencies -->
@@ -623,7 +623,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-dbcp2</artifactId>
-        <version>2.1</version>
+        <version>2.11.0</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -639,6 +639,7 @@
       </dependency>
 
       <dependency>
+        <!-- this was moved to jakarta.xml.bind-api -->
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
         <version>${jaxb.api.version}</version>

--- a/rewrite/pom.xml
+++ b/rewrite/pom.xml
@@ -22,7 +22,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.10</version>
+        <version>3.6.1</version>
         <executions>
           <execution>
             <id>copy-build-artifact</id>

--- a/rewrite/pom.xml
+++ b/rewrite/pom.xml
@@ -47,6 +47,11 @@
         </executions>
       </plugin>
 
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.4.0</version>
+      </plugin>
     </plugins>
   </build>
 

--- a/rewrite/pom.xml
+++ b/rewrite/pom.xml
@@ -2,7 +2,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.duracloud.snapshot</groupId>
   <artifactId>ROOT</artifactId>
   <packaging>war</packaging>
   <version>3.2.0-SNAPSHOT</version>

--- a/snapshot-bridge-webapp/pom.xml
+++ b/snapshot-bridge-webapp/pom.xml
@@ -3,7 +3,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <version>3.2.0-SNAPSHOT</version>
-  <groupId>org.duracloud.snapshot</groupId>
   <artifactId>bridge</artifactId>
   <packaging>war</packaging>
   <name>DuraCloud to Bridge Web Application</name>

--- a/snapshot-bridge-webapp/pom.xml
+++ b/snapshot-bridge-webapp/pom.xml
@@ -50,7 +50,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.4</version>
+        <version>3.4.0</version>
         <configuration>
           <warName>${project.artifactId}-${project.version}</warName>
           <webResources>
@@ -64,7 +64,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.10</version>
+        <version>3.6.1</version>
         <executions>
           <execution>
             <id>copy-build-artifact</id>

--- a/snapshot-bridge-webapp/pom.xml
+++ b/snapshot-bridge-webapp/pom.xml
@@ -220,8 +220,8 @@
     </dependency>
 
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
     </dependency>
 
     <dependency>

--- a/snapshot-bridge-webapp/src/main/java/org/duracloud/snapshot/bridge/rest/SnapshotResource.java
+++ b/snapshot-bridge-webapp/src/main/java/org/duracloud/snapshot/bridge/rest/SnapshotResource.java
@@ -620,7 +620,7 @@ public class SnapshotResource {
                 log.info("cleaning up post exception...");
                 try {
                     log.debug("deleting newly created snapshot...");
-                    snapshotRepo.delete(snapshot.getId());
+                    snapshotRepo.deleteById(snapshot.getId());
                 } catch (Exception e) {
                     log.error("failed to cleanup snapshot " + snapshotId + ": " +
                               e.getMessage(), e);
@@ -778,7 +778,7 @@ public class SnapshotResource {
                 pageSize = 1000;
             }
 
-            PageRequest pageable = new PageRequest(page, pageSize);
+            PageRequest pageable = PageRequest.of(page, pageSize);
 
             List<SnapshotContentItem> items;
             if (null == prefix || prefix.equals("")) {

--- a/snapshot-bridge-webapp/src/test/java/org/duracloud/snapshot/bridge/rest/RestoreResourceTest.java
+++ b/snapshot-bridge-webapp/src/test/java/org/duracloud/snapshot/bridge/rest/RestoreResourceTest.java
@@ -15,7 +15,6 @@ import static org.junit.Assert.assertEquals;
 import java.util.Date;
 import javax.ws.rs.core.Response;
 
-import org.codehaus.jettison.json.JSONException;
 import org.duracloud.snapshot.SnapshotException;
 import org.duracloud.snapshot.common.test.SnapshotTestBase;
 import org.duracloud.snapshot.db.model.DuracloudEndPointConfig;
@@ -162,7 +161,7 @@ public class RestoreResourceTest extends SnapshotTestBase {
     }
 
     @Test
-    public void testGetRestore() throws SnapshotException, JSONException {
+    public void testGetRestore() throws SnapshotException {
         String restorationId = "restoration-id";
         Restoration restoration = setupRestoration();
         expect(manager.get(restorationId)).andReturn(restoration);
@@ -173,7 +172,7 @@ public class RestoreResourceTest extends SnapshotTestBase {
     }
 
     @Test
-    public void testGetRestoreBySnapshot() throws SnapshotException, JSONException {
+    public void testGetRestoreBySnapshot() throws SnapshotException {
         String snapshotId = "snapshot-id";
         Restoration restoration = setupRestoration();
         expect(manager.getBySnapshotId(snapshotId)).andReturn(restoration);

--- a/snapshot-bridge-webapp/src/test/java/org/duracloud/snapshot/bridge/rest/SnapshotResourceTest.java
+++ b/snapshot-bridge-webapp/src/test/java/org/duracloud/snapshot/bridge/rest/SnapshotResourceTest.java
@@ -25,7 +25,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 import org.apache.http.HttpStatus;
-import org.codehaus.jettison.json.JSONException;
 import org.duracloud.client.ContentStore;
 import org.duracloud.common.constant.Constants;
 import org.duracloud.common.notification.NotificationManager;
@@ -304,7 +303,7 @@ public class SnapshotResourceTest extends SnapshotTestBase {
     }
 
     @Test
-    public void testComplete() throws SnapshotException, JSONException {
+    public void testComplete() throws SnapshotException {
         String snapshotId = "snapshot-name";
         List<String> snapshotAlternateIds = new ArrayList<String>();
         String altId1 = "alternate-name-1";
@@ -335,7 +334,7 @@ public class SnapshotResourceTest extends SnapshotTestBase {
     }
 
     @Test
-    public void testCompleteDuplicateAltId() throws SnapshotException, JSONException {
+    public void testCompleteDuplicateAltId() throws SnapshotException {
         String snapshotId = "snapshot-name";
         List<String> snapshotAlternateIds = new ArrayList<String>();
         String altId1 = "alternate-name-1";
@@ -359,7 +358,7 @@ public class SnapshotResourceTest extends SnapshotTestBase {
     }
 
     @Test
-    public void testCancel() throws SnapshotException, JSONException {
+    public void testCancel() throws SnapshotException {
         String snapshotId = "snapshot-name";
 
         expect(this.snapshotRepo.findByName(snapshotId)).andReturn(snapshot);
@@ -375,7 +374,7 @@ public class SnapshotResourceTest extends SnapshotTestBase {
     }
 
     @Test
-    public void testCancelFailure() throws SnapshotException, JSONException {
+    public void testCancelFailure() throws SnapshotException {
         String snapshotId = "snapshot-name";
 
         expect(this.snapshotRepo.findByName(snapshotId)).andReturn(snapshot);
@@ -386,7 +385,6 @@ public class SnapshotResourceTest extends SnapshotTestBase {
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatus());
         assertTrue(response.getEntity() instanceof ResponseDetails);
         assertNotNull(((ResponseDetails) response.getEntity()).getMessage());
-
     }
 
     @Test

--- a/snapshot-common-db/pom.xml
+++ b/snapshot-common-db/pom.xml
@@ -74,8 +74,8 @@
     </dependency>
 
     <dependency>
-      <groupId>com.wix</groupId>
-      <artifactId>wix-embedded-mysql</artifactId>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mysql</artifactId>
     </dependency>
 
   </dependencies>

--- a/snapshot-common-db/pom.xml
+++ b/snapshot-common-db/pom.xml
@@ -40,8 +40,8 @@
     </dependency>
 
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
     </dependency>
 
     <dependency>

--- a/snapshot-common-db/pom.xml
+++ b/snapshot-common-db/pom.xml
@@ -3,7 +3,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <version>3.2.0-SNAPSHOT</version>
-  <groupId>org.duracloud.snapshot</groupId>
   <artifactId>snapshot-common-db</artifactId>
   <packaging>jar</packaging>
   <name>Snapshot Common DB</name>

--- a/snapshot-common-db/src/main/java/org/duracloud/snapshot/db/SnapshotDatabaseConfig.java
+++ b/snapshot-common-db/src/main/java/org/duracloud/snapshot/db/SnapshotDatabaseConfig.java
@@ -47,7 +47,7 @@ public class SnapshotDatabaseConfig {
     @Bean(name = SNAPSHOT_REPO_DATA_SOURCE_BEAN, destroyMethod = "close")
     public BasicDataSource snapshotDataSource() {
         BasicDataSource dataSource = new BasicDataSource();
-        dataSource.setDriverClassName("com.mysql.jdbc.Driver");
+        dataSource.setDriverClassName("com.mysql.cj.jdbc.Driver");
         dataSource.setUrl(MessageFormat.format("jdbc:mysql://{0}:{1}/{2}" +
                                                "?useLegacyDatetimeCode=false" +
                                                "&serverTimezone=GMT" +

--- a/snapshot-common-db/src/test/java/org/duracloud/snapshot/db/repo/SnapshotRepoTest.java
+++ b/snapshot-common-db/src/test/java/org/duracloud/snapshot/db/repo/SnapshotRepoTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
  * @author Daniel Bernstein
  */
 public class SnapshotRepoTest extends JpaIntegrationTestBase {
+
     @Test
     public void testFindByStatusOrderBySnapshotDateAsc() {
         SnapshotRepo repo = context.getBean(SnapshotRepo.class);

--- a/snapshot-common-db/src/test/resources/db_init.sql
+++ b/snapshot-common-db/src/test/resources/db_init.sql
@@ -1,2 +1,1 @@
-grant all privileges on mill.* to "user"@"localhost" identified by "pass";
-flush privileges;
+ALTER DATABASE snapshot CHARACTER SET utf8 COLLATE utf8_general_ci;

--- a/snapshot-common-test/pom.xml
+++ b/snapshot-common-test/pom.xml
@@ -3,7 +3,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.duracloud.snapshot</groupId>
   <artifactId>snapshot-common-test</artifactId>
   <packaging>jar</packaging>
   <version>3.2.0-SNAPSHOT</version>

--- a/snapshot-common/pom.xml
+++ b/snapshot-common/pom.xml
@@ -3,7 +3,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <version>3.2.0-SNAPSHOT</version>
-  <groupId>org.duracloud.snapshot</groupId>
   <artifactId>snapshot-common</artifactId>
   <packaging>jar</packaging>
   <name>Snapshot Common</name>

--- a/snapshot-service-impl/pom.xml
+++ b/snapshot-service-impl/pom.xml
@@ -184,8 +184,8 @@
 
     <!-- MySQL database driver -->
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
     </dependency>
 
     <dependency>

--- a/snapshot-service-impl/pom.xml
+++ b/snapshot-service-impl/pom.xml
@@ -22,7 +22,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.2</version>
+        <version>3.5.1</version>
         <configuration>
           <createDependencyReducedPom>false</createDependencyReducedPom>
         </configuration>

--- a/snapshot-service-impl/pom.xml
+++ b/snapshot-service-impl/pom.xml
@@ -3,7 +3,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.duracloud.snapshot</groupId>
   <artifactId>snapshot-service-impl</artifactId>
   <packaging>jar</packaging>
   <version>3.2.0-SNAPSHOT</version>

--- a/snapshot-service-impl/pom.xml
+++ b/snapshot-service-impl/pom.xml
@@ -201,7 +201,7 @@
     <dependency>
       <groupId>org.mapdb</groupId>
       <artifactId>mapdb</artifactId>
-      <version>3.0.5</version>
+      <version>3.0.10</version>
     </dependency>
 
     <dependency>

--- a/snapshot-service-impl/src/main/java/org/duracloud/snapshot/service/impl/SnapshotManagerImpl.java
+++ b/snapshot-service-impl/src/main/java/org/duracloud/snapshot/service/impl/SnapshotManagerImpl.java
@@ -186,16 +186,19 @@ public class SnapshotManagerImpl implements SnapshotManager {
     @Transactional
     public Snapshot addAlternateSnapshotIds(Snapshot snapshot, List<String> alternateIds)
         throws AlternateIdAlreadyExistsException {
-        snapshot = this.snapshotRepo.findOne(snapshot.getId());
-        for (String altId : alternateIds) {
-            Snapshot altSnapshot = this.snapshotRepo.findBySnapshotAlternateIds(altId);
-            if (altSnapshot != null && !altSnapshot.getName().equals(snapshot.getName())) {
-                throw new AlternateIdAlreadyExistsException("The alternate snapshot id ("
-                                                            + altId + ") already exists in another snapshot (" +
-                                                            altSnapshot.getName() + ")");
+        final var query = snapshotRepo.findById(snapshot.getId());
+        if (query.isPresent()) {
+            snapshot = query.get();
+            for (String altId : alternateIds) {
+                Snapshot altSnapshot = this.snapshotRepo.findBySnapshotAlternateIds(altId);
+                if (altSnapshot != null && !altSnapshot.getName().equals(snapshot.getName())) {
+                    throw new AlternateIdAlreadyExistsException("The alternate snapshot id ("
+                                                                + altId + ") already exists in another snapshot (" +
+                                                                altSnapshot.getName() + ")");
+                }
             }
+            snapshot.addSnapshotAlternateIds(alternateIds);
         }
-        snapshot.addSnapshotAlternateIds(alternateIds);
         return this.snapshotRepo.saveAndFlush(snapshot);
     }
 

--- a/snapshot-service-impl/src/test/java/org/duracloud/snapshot/service/impl/SnapshotManagerImplTest.java
+++ b/snapshot-service-impl/src/test/java/org/duracloud/snapshot/service/impl/SnapshotManagerImplTest.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -257,7 +258,7 @@ public class SnapshotManagerImplTest extends SnapshotTestBase {
         List<String> alternateIds = Arrays.asList(new String[] {altTestId});
         String snapshotId = "test";
         expect(snapshot.getId()).andReturn(1l);
-        expect(this.snapshotRepo.findOne(isA(Long.class))).andReturn(snapshot);
+        expect(this.snapshotRepo.findById(isA(Long.class))).andReturn(Optional.of(snapshot));
 
         expect(snapshot.getName()).andReturn(snapshotId).times(2);
         expect(this.snapshotRepo.findBySnapshotAlternateIds(altTestId))
@@ -279,7 +280,7 @@ public class SnapshotManagerImplTest extends SnapshotTestBase {
         expect(snapshot2.getName()).andReturn("snapshot2").atLeastOnce();
 
         expect(snapshot.getId()).andReturn(1l);
-        expect(this.snapshotRepo.findOne(isA(Long.class))).andReturn(snapshot);
+        expect(this.snapshotRepo.findById(isA(Long.class))).andReturn(Optional.of(snapshot));
 
         expect(this.snapshotRepo.findBySnapshotAlternateIds(altTestId)).andReturn(snapshot2);
         replayAll();

--- a/snapshot-service/pom.xml
+++ b/snapshot-service/pom.xml
@@ -3,7 +3,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <version>3.2.0-SNAPSHOT</version>
-  <groupId>org.duracloud.snapshot</groupId>
   <artifactId>snapshot-service</artifactId>
   <packaging>jar</packaging>
   <name>Snapshot Service Layer</name>


### PR DESCRIPTION
# Summary

This brings in dependency updates from other Duracloud projects and changes the compiler to use Java 17.

# Changes

* Set Java 17 as release version
* Replace wix with testcontainers for tests
* Update duracloud dependencies to 8.0.0
* Update spring dependencies to 5.3.29
* Update spring data dependencies to 2.7.15
* Update spring security dependencies to 5.8.5
* Update hibernate dependencies to 5.4.33
* Update slf4j dependency to 2.0.9
* Update logback dependency to 1.4.14
* Update mysql connector dependency to 8.2.0
* Update jackson dependency to 2.16.0
* Update various maven plugin versions